### PR TITLE
Check If Caught Exception inherits Type `Exception`

### DIFF
--- a/Logging/RockLib.Logging.Analyzers.Test/CaughtExceptionShouldBeLoggedAnalyzerTests.cs
+++ b/Logging/RockLib.Logging.Analyzers.Test/CaughtExceptionShouldBeLoggedAnalyzerTests.cs
@@ -6,7 +6,7 @@ using RockLibVerifier = RockLib.Logging.Analyzers.Test.CSharpAnalyzerVerifier<
 namespace RockLib.Logging.Analyzers.Test
 {
     public class CaughtExceptionShouldBeLoggedAnalyzerTests
-    {
+    {        
         [Fact(DisplayName = "Diagnostics are reported when exception is not passed to logging extension methods")]
         public async Task DiagnosticsReported1()
         {
@@ -325,6 +325,42 @@ public class Test
             var logEntry = new LogEntry(""A log without exception"", LogLevel.Info);
             logEntry.Exception = ex;
             logger.Log(logEntry);
+        }
+    }
+}");
+        }
+
+        [Fact(DisplayName = "Diagnostics are not reported when exception is filtered and logged")]
+        public async Task DiagnosticsReported7()
+        {
+            await RockLibVerifier.VerifyAnalyzerAsync(@"
+using RockLib.Logging;
+using RockLib.Logging.SafeLogging;
+using System;
+
+public class Test
+{
+    public void Call_Log_Within_Catch_Block(ILogger logger)
+    {
+        try
+        {
+            throw new ArgumentException(""This is a test"");
+        }
+        catch (ArgumentException ex)
+        {
+            logger.Debug(""A debug log without exception"", ex);
+            logger.Info(""An info log without exception"", ex);
+            logger.Warn(""A warn log without exception"", ex);
+            logger.Error(""An error log without exception"", ex);
+            logger.Fatal(""A fatal log without exception"", ex);
+            logger.Audit(""An audit log without exception"", ex);
+
+            logger.DebugSanitized(""A debug log without exception"", ex, new { foo = 123 });
+            logger.InfoSanitized(""An info log without exception"", ex, new { foo = 123 });
+            logger.WarnSanitized(""A warn log without exception"", ex, new { foo = 123 });
+            logger.ErrorSanitized(""An error log without exception"", ex, new { foo = 123 });
+            logger.FatalSanitized(""A fatal log without exception"", ex, new { foo = 123 });
+            logger.AuditSanitized(""An audit log without exception"", ex, new { foo = 123 });
         }
     }
 }");

--- a/Logging/RockLib.Logging.Analyzers.Test/CaughtExceptionShouldBeLoggedAnalyzerTests.cs
+++ b/Logging/RockLib.Logging.Analyzers.Test/CaughtExceptionShouldBeLoggedAnalyzerTests.cs
@@ -6,7 +6,7 @@ using RockLibVerifier = RockLib.Logging.Analyzers.Test.CSharpAnalyzerVerifier<
 namespace RockLib.Logging.Analyzers.Test
 {
     public class CaughtExceptionShouldBeLoggedAnalyzerTests
-    {        
+    {
         [Fact(DisplayName = "Diagnostics are reported when exception is not passed to logging extension methods")]
         public async Task DiagnosticsReported1()
         {
@@ -267,7 +267,7 @@ public class Test
         {
             throw new ArgumentException(""This is a test"");
         }
-        catch (Exception ex)
+        catch (ArgumentException ex)
         {
             var logEntry = new LogEntry(""A log without exception"", ex, LogLevel.Info);
             logger.Log(logEntry);
@@ -292,7 +292,7 @@ public class Test
         {
             throw new ArgumentException(""This is a test"");
         }
-        catch (Exception ex)
+        catch (ArgumentException ex)
         {
             var logEntry = new LogEntry(""A log without exception"", LogLevel.Info)
             {
@@ -303,6 +303,8 @@ public class Test
     }
 }");
         }
+
+
 
         [Fact(DisplayName = "No diagnostics are reported when exception is passed to log entry property setter")]
         public async Task NoDiagnosticsReported4()

--- a/Logging/RockLib.Logging.Analyzers.Test/CaughtExceptionShouldBeLoggedAnalyzerTests.cs
+++ b/Logging/RockLib.Logging.Analyzers.Test/CaughtExceptionShouldBeLoggedAnalyzerTests.cs
@@ -304,8 +304,6 @@ public class Test
 }");
         }
 
-
-
         [Fact(DisplayName = "No diagnostics are reported when exception is passed to log entry property setter")]
         public async Task NoDiagnosticsReported4()
         {

--- a/Logging/RockLib.Logging.Analyzers/CaughtExceptionShouldBeLoggedAnalyzer.cs
+++ b/Logging/RockLib.Logging.Analyzers/CaughtExceptionShouldBeLoggedAnalyzer.cs
@@ -121,39 +121,7 @@ namespace RockLib.Logging.Analyzers
                     parent = parent.Parent;
                 }
                 return null;
-            }
-
-            private bool IsException(ITypeSymbol symbol)
-            {
-                if (symbol.Name.Equals("Exception"))
-                {
-                    return true;
-                }
-
-                if (symbol.BaseType != null)
-                {
-                    if (symbol.BaseType.Name.Equals("Exception"))
-                    {
-                        return true;
-                    }
-                    return IsException(symbol.BaseType);
-                }
-
-                return false;
-            }
-
-            private ImmutableArray<ILocalSymbol> GetRootMethodBody(IOperation op, List<ILocalSymbol> symbolArray)
-            {
-                if (op.Parent is IBlockOperation block)
-                {
-                    symbolArray.AddRange(block.Locals);
-                }
-
-                if (op.Parent == null)
-                    return symbolArray.ToImmutableArray();
-
-                return GetRootMethodBody(op.Parent, symbolArray);
-            }
+            }          
 
             private bool IsExceptionSet(IObjectCreationOperation logEntryCreation, IOperation logEntryArgumentValue,
                 ICatchClauseOperation catchClause)

--- a/Logging/RockLib.Logging.Analyzers/CaughtExceptionShouldBeLoggedAnalyzer.cs
+++ b/Logging/RockLib.Logging.Analyzers/CaughtExceptionShouldBeLoggedAnalyzer.cs
@@ -8,7 +8,7 @@ using System.Collections.Immutable;
 namespace RockLib.Logging.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public partial class CaughtExceptionShouldBeLoggedAnalyzer : DiagnosticAnalyzer
+    public class CaughtExceptionShouldBeLoggedAnalyzer : DiagnosticAnalyzer
     {
         private static readonly LocalizableString _title = "Caught exception should be logged";
         private static readonly LocalizableString _messageFormat = "The caught exception should be passed into the logging method";
@@ -52,7 +52,7 @@ namespace RockLib.Logging.Analyzers
             context.RegisterOperationAction(analyzer.Analyze, OperationKind.Invocation);
         }
 
-        private partial class InvocationOperationAnalyzer
+        private class InvocationOperationAnalyzer
         {
             private readonly INamedTypeSymbol _loggingExtensionsType;
             private readonly INamedTypeSymbol _safeLoggingExtensionsType;

--- a/Logging/RockLib.Logging.Analyzers/CommonExtensions.cs
+++ b/Logging/RockLib.Logging.Analyzers/CommonExtensions.cs
@@ -89,7 +89,7 @@ namespace RockLib.Logging.Analyzers
             while (true)
             {
                 type = type.BaseType;
-                if (type.SpecialType == SpecialType.System_Object)
+                if (type == null || type.SpecialType == SpecialType.System_Object)
                     break;
                 properties = properties.Concat(GetProperties(type));
             }

--- a/Logging/RockLib.Logging.Analyzers/CommonExtensions.cs
+++ b/Logging/RockLib.Logging.Analyzers/CommonExtensions.cs
@@ -10,6 +10,24 @@ namespace RockLib.Logging.Analyzers
 {
     public static class CommonExtensions
     {
+        public static bool IsException(this ITypeSymbol typeSymbol)
+        {
+            if (typeSymbol.Name.Equals("Exception"))
+            {
+                return true;
+            }
+
+            if (typeSymbol.BaseType != null)
+            {
+                if (typeSymbol.BaseType.Name.Equals("Exception"))
+                {
+                    return true;
+                }
+                return IsException(typeSymbol.BaseType);
+            }
+
+            return false;
+        }
         public static IObjectCreationOperation GetLogEntryCreationOperation(this IArgumentOperation logEntryArgument)
         {
             if (logEntryArgument.Value is IObjectCreationOperation objectCreation)

--- a/Logging/RockLib.Logging.Analyzers/CommonExtensions.cs
+++ b/Logging/RockLib.Logging.Analyzers/CommonExtensions.cs
@@ -10,24 +10,11 @@ namespace RockLib.Logging.Analyzers
 {
     public static class CommonExtensions
     {
-        public static bool IsException(this ITypeSymbol typeSymbol)
+        public static bool IsException(this ITypeSymbol typeSymbol, ITypeSymbol exceptionType, Compilation compilation)
         {
-            if (typeSymbol.Name.Equals("Exception"))
-            {
-                return true;
-            }
-
-            if (typeSymbol.BaseType != null)
-            {
-                if (typeSymbol.BaseType.Name.Equals("Exception"))
-                {
-                    return true;
-                }
-                return IsException(typeSymbol.BaseType);
-            }
-
-            return false;
+            return compilation.ClassifyCommonConversion(typeSymbol, exceptionType).IsImplicit;
         }
+
         public static IObjectCreationOperation GetLogEntryCreationOperation(this IArgumentOperation logEntryArgument)
         {
             if (logEntryArgument.Value is IObjectCreationOperation objectCreation)

--- a/Logging/RockLib.Logging.Analyzers/Walkers/CatchParameterWalker.cs
+++ b/Logging/RockLib.Logging.Analyzers/Walkers/CatchParameterWalker.cs
@@ -7,10 +7,14 @@ namespace RockLib.Logging.Analyzers
     internal class CatchParameterWalker : OperationWalker
     {
         private readonly IInvocationOperation _invocationOperation;
+        private readonly ITypeSymbol _exceptionType;
+        private readonly Compilation _compilation;
 
-        public CatchParameterWalker(IInvocationOperation invocationOperation)
+        public CatchParameterWalker(IInvocationOperation invocationOperation, ITypeSymbol exceptionType, Compilation compilation)
         {
             _invocationOperation = invocationOperation;
+            _exceptionType = exceptionType;
+            _compilation = compilation;
         }
 
         public bool IsExceptionCaught { get; private set; }
@@ -28,7 +32,7 @@ namespace RockLib.Logging.Analyzers
             else if (argument.Value is ILocalReferenceOperation localReference
             && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation variableDeclarator)
             {
-                var isException = localReference.Type.IsException();
+                var isException = localReference.Type.IsException(_exceptionType, _compilation);
                 IsExceptionCaught = isException && SymbolEqualityComparer.Default.Equals(localReference.Local, variableDeclarator.Symbol);
             }
             else if (argument.Value is IConversionOperation conversion
@@ -36,8 +40,9 @@ namespace RockLib.Logging.Analyzers
                 && !conversion.ConstantValue.HasValue
                 && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation catchVariableDeclarator)
             {
+                var isEx = _compilation.ClassifyCommonConversion(convertedLocalReference.Type, _exceptionType).IsImplicit;
                 var doesCaughtExceptionMatchArgument = SymbolEqualityComparer.Default.Equals(convertedLocalReference.Local, catchVariableDeclarator.Symbol);
-                IsExceptionCaught = conversion.Type.IsException() && doesCaughtExceptionMatchArgument;
+                IsExceptionCaught = convertedLocalReference.Type.IsException(_exceptionType, _compilation) && doesCaughtExceptionMatchArgument;
             }
 
             base.VisitCatchClause(catchClause);

--- a/Logging/RockLib.Logging.Analyzers/Walkers/CatchParameterWalker.cs
+++ b/Logging/RockLib.Logging.Analyzers/Walkers/CatchParameterWalker.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+using System.Linq;
+
+namespace RockLib.Logging.Analyzers
+{
+    internal class CatchParameterWalker : OperationWalker
+    {
+        private readonly IInvocationOperation _invocationOperation;
+
+        public CatchParameterWalker(IInvocationOperation invocationOperation)
+        {
+            _invocationOperation = invocationOperation;
+        }
+
+        public bool IsExceptionCaught { get; private set; }
+
+        public override void VisitCatchClause(ICatchClauseOperation catchClause)
+        {
+            if (catchClause.ExceptionDeclarationOrExpression is null)
+                IsExceptionCaught = true;
+
+            var argument = _invocationOperation.Arguments.FirstOrDefault(a => a.Parameter.Name == "exception");
+            if (argument == null || argument.IsImplicit)
+            {
+                IsExceptionCaught = false;
+            }
+            else if (argument.Value is ILocalReferenceOperation localReference
+            && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation variableDeclarator)
+            {
+                var isException = localReference.Type.IsException();
+                IsExceptionCaught = isException && SymbolEqualityComparer.Default.Equals(localReference.Local, variableDeclarator.Symbol);
+            }
+            else if (argument.Value is IConversionOperation conversion
+                && conversion.Operand is ILocalReferenceOperation convertedLocalReference
+                && !conversion.ConstantValue.HasValue
+                && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation catchVariableDeclarator)
+            {
+                var doesCaughtExceptionMatchArgument = SymbolEqualityComparer.Default.Equals(convertedLocalReference.Local, catchVariableDeclarator.Symbol);
+                IsExceptionCaught = conversion.Type.IsException() && doesCaughtExceptionMatchArgument;
+            }
+
+            base.VisitCatchClause(catchClause);
+        }
+    }
+}

--- a/Logging/RockLib.Logging.Analyzers/Walkers/LogEntryCreatedWalker.cs
+++ b/Logging/RockLib.Logging.Analyzers/Walkers/LogEntryCreatedWalker.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+using RockLib.Analyzers.Common;
+using System.Linq;
+
+namespace RockLib.Logging.Analyzers
+{
+    internal class LogEntryCreatedWalker : OperationWalker
+    {
+        private readonly IOperation _logEntryArgumentValue;
+        private readonly IObjectCreationOperation _createOperation;
+
+        public LogEntryCreatedWalker(IOperation logEntryArgumentValue, IObjectCreationOperation createOperation)
+        {
+            _logEntryArgumentValue = logEntryArgumentValue;
+            _createOperation = createOperation;
+        }
+
+        public bool IsExceptionSet { get; private set; }
+
+        public override void VisitCatchClause(ICatchClauseOperation catchClause)
+        {
+            if (_createOperation.Arguments.Length > 0)
+            {
+                var exceptionArgument = _createOperation.Arguments.FirstOrDefault(a => a.Parameter.Name == "exception");
+                if (exceptionArgument != null
+                    && !exceptionArgument.IsImplicit
+                    && exceptionArgument.Value is ILocalReferenceOperation localReference
+                    && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation variableDeclarator
+                    && SymbolEqualityComparer.Default.Equals(localReference.Local, variableDeclarator.Symbol))
+                {
+                    IsExceptionSet = true;
+                    return;
+                }
+                else if (exceptionArgument != null
+                    && exceptionArgument.Value is IConversionOperation conversion
+                    && conversion.Operand is ILocalReferenceOperation convertedLocalReference
+                    && !conversion.ConstantValue.HasValue
+                    && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation catchVariableDeclarator)
+                {
+                    var doesCaughtExceptionMatchArgument = SymbolEqualityComparer.Default.Equals(convertedLocalReference.Local, catchVariableDeclarator.Symbol);
+                    IsExceptionSet = conversion.Type.IsException() && doesCaughtExceptionMatchArgument;
+                    return;
+                }
+            }
+
+            if (_createOperation.Initializer != null)
+            {
+                foreach (var initializer in _createOperation.Initializer.Initializers)
+                {
+                    if (initializer is ISimpleAssignmentOperation assignment
+                        && assignment.Target is IPropertyReferenceOperation property
+                        && property.Property.Name == "Exception"
+                        && assignment.Value is ILocalReferenceOperation localReference
+                        && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation variableDeclarator
+                        && SymbolEqualityComparer.Default.Equals(localReference.Local, variableDeclarator.Symbol))
+                    {
+                        IsExceptionSet = true;
+                        return;
+                    }
+
+                    if (initializer is ISimpleAssignmentOperation conversionAssignment
+                       && conversionAssignment.Target is IPropertyReferenceOperation propertyRef
+                       && propertyRef.Property.Name == "Exception"
+                       && conversionAssignment.Value is IConversionOperation conversionOperation
+                       && conversionOperation.Operand is ILocalReferenceOperation localRef
+                       && catchClause.ExceptionDeclarationOrExpression is IVariableDeclaratorOperation caughtVariable
+                       && localRef.Local.Type.IsException()
+                       && SymbolEqualityComparer.Default.Equals(localRef.Local, caughtVariable.Symbol))
+                    {
+                        IsExceptionSet = true;
+                        return;
+                    }
+                }
+            }
+
+            if (_logEntryArgumentValue is ILocalReferenceOperation logEntryReference)
+            {
+                var visitor = new SimpleAssignmentWalker(logEntryReference);
+                visitor.Visit(_createOperation.GetRootOperation());
+                IsExceptionSet = visitor.IsExceptionSet;
+                return;
+            }
+
+            base.VisitCatchClause(catchClause);
+        }
+    }
+}

--- a/Logging/RockLib.Logging.Analyzers/Walkers/SimpleAssignmentWalker.cs
+++ b/Logging/RockLib.Logging.Analyzers/Walkers/SimpleAssignmentWalker.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace RockLib.Logging.Analyzers
+{
+    internal class SimpleAssignmentWalker : OperationWalker
+    {
+        private readonly ILocalReferenceOperation _logEntryReference;
+
+        public SimpleAssignmentWalker(ILocalReferenceOperation logEntryReference)
+        {
+            _logEntryReference = logEntryReference;
+        }
+
+        public bool IsExceptionSet { get; private set; }
+
+        public override void VisitSimpleAssignment(ISimpleAssignmentOperation operation)
+        {
+            if (operation.Target is IPropertyReferenceOperation property
+                && property.Property.Name == "Exception"
+                && property.Instance is ILocalReferenceOperation localReference
+                && SymbolEqualityComparer.Default.Equals(localReference.Local, _logEntryReference.Local))
+            {
+                var a = property.Property as IMemberReferenceOperation;
+                IsExceptionSet = true;
+            }
+            else if (operation.Target is IPropertyReferenceOperation propertyRef
+                && propertyRef.Property.Name == "Exception"
+                && operation.Value is IConversionOperation conversionOperation
+                && conversionOperation.Operand is ILocalReferenceOperation localRef
+                && SymbolEqualityComparer.Default.Equals(localRef.Local, _logEntryReference.Local))
+            {
+
+                IsExceptionSet = true;
+            }
+
+            base.VisitSimpleAssignment(operation);
+        }
+    }
+}

--- a/Logging/RockLib.Logging.Analyzers/Walkers/SimpleAssignmentWalker.cs
+++ b/Logging/RockLib.Logging.Analyzers/Walkers/SimpleAssignmentWalker.cs
@@ -21,7 +21,6 @@ namespace RockLib.Logging.Analyzers
                 && property.Instance is ILocalReferenceOperation localReference
                 && SymbolEqualityComparer.Default.Equals(localReference.Local, _logEntryReference.Local))
             {
-                var a = property.Property as IMemberReferenceOperation;
                 IsExceptionSet = true;
             }
             else if (operation.Target is IPropertyReferenceOperation propertyRef
@@ -30,7 +29,6 @@ namespace RockLib.Logging.Analyzers
                 && conversionOperation.Operand is ILocalReferenceOperation localRef
                 && SymbolEqualityComparer.Default.Equals(localRef.Local, _logEntryReference.Local))
             {
-
                 IsExceptionSet = true;
             }
 


### PR DESCRIPTION
## Description

There was a bug in `RockLib.Logging.Analyzers` that was warning "The caught exception should be passed into the logging method" if an exception that inherits `Exception`. 

In this example, since ex isn't of type `Exception`, a warning is displayed when it shouldn't.
```c#
try
  {
    DoSomething();  
  }
  catch(ArgumentException ex)  
  {
    // Analyzer warning is displayed here:
    logger.Error("An error occurred", ex);
  }
}
```

The variable ex is considered an `IConversionOperation` which needs to be compared to the `Exception` argument in the `.Error()` method on the `ILogger` and `LogEntry`.